### PR TITLE
Remove `CameraBuffer`

### DIFF
--- a/game_render/src/camera.rs
+++ b/game_render/src/camera.rs
@@ -3,11 +3,8 @@ use std::f32::consts::PI;
 use bytemuck::{Pod, Zeroable};
 use game_common::components::Transform;
 use game_common::math::Ray;
-use game_tracing::trace_span;
 use game_window::windows::WindowId;
 use glam::{Mat4, UVec2, Vec2, Vec3};
-use wgpu::util::{BufferInitDescriptor, DeviceExt};
-use wgpu::{Buffer, BufferUsages, Device};
 
 use crate::texture::RenderImageId;
 
@@ -86,38 +83,6 @@ pub const OPENGL_TO_WGPU: Mat4 = Mat4::from_cols_array_2d(&[
     [0.0, 0.0, 0.5, 0.0],
     [0.0, 0.0, 0.5, 1.0],
 ]);
-
-#[derive(Debug)]
-pub struct CameraBuffer {
-    pub transform: Transform,
-    pub projection: Projection,
-    pub buffer: Buffer,
-    pub target: RenderTarget,
-}
-
-impl CameraBuffer {
-    pub fn new(
-        transform: Transform,
-        projection: Projection,
-        device: &Device,
-        target: RenderTarget,
-    ) -> Self {
-        let _span = trace_span!("CameraBuffer::new").entered();
-
-        let buffer = device.create_buffer_init(&BufferInitDescriptor {
-            label: Some("camera_transform_buffer"),
-            contents: bytemuck::cast_slice(&[CameraUniform::new(transform, projection)]),
-            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
-        });
-
-        Self {
-            transform,
-            projection,
-            buffer,
-            target,
-        }
-    }
-}
 
 #[derive(Copy, Clone, Debug, Zeroable, Pod)]
 #[repr(C)]

--- a/game_render/src/render_pass.rs
+++ b/game_render/src/render_pass.rs
@@ -13,7 +13,7 @@ use wgpu::{
 };
 
 use crate::buffer::{DynamicBuffer, IndexBuffer};
-use crate::camera::{CameraBuffer, CameraUniform, RenderTarget};
+use crate::camera::{Camera, CameraUniform, RenderTarget};
 use crate::depth_stencil::DepthData;
 use crate::entities::{CameraId, ObjectId};
 use crate::forward::ForwardPipeline;
@@ -31,7 +31,7 @@ pub struct GpuObject {
 }
 
 pub struct GpuState {
-    pub cameras: HashMap<CameraId, CameraBuffer>,
+    pub cameras: HashMap<CameraId, Camera>,
     pub objects: HashMap<ObjectId, GpuObject>,
     pub directional_lights: Buffer,
     pub point_lights: Buffer,
@@ -85,7 +85,7 @@ impl Node for RenderPass {
 
         state.update_buffers(ctx.device, ctx.queue, &self.forward, ctx.mipmap);
 
-        for cam in state.camera_buffers.values() {
+        for cam in state.cameras.values() {
             if cam.target == ctx.render_target {
                 self.update_depth_stencil(ctx.render_target, ctx.size, ctx.device);
 
@@ -117,7 +117,7 @@ impl RenderPass {
     fn render_camera_target(
         &self,
         state: &RenderState,
-        camera: &CameraBuffer,
+        camera: &Camera,
         ctx: &mut RenderContext<'_>,
     ) {
         let _span = trace_span!("ForwardPass::render_camera_target").entered();

--- a/game_render/src/state.rs
+++ b/game_render/src/state.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
 
-use game_common::components::Transform;
 use game_tracing::trace_span;
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::{BindGroup, BindGroupDescriptor, BindGroupEntry, Buffer, BufferUsages, Device, Queue};
 
 use crate::buffer::{DynamicBuffer, IndexBuffer};
-use crate::camera::{Camera, CameraBuffer};
+use crate::camera::Camera;
 use crate::entities::{CameraId, DirectionalLightId, Object, ObjectId, PointLightId, SpotLightId};
 use crate::forward::ForwardPipeline;
 use crate::light::pipeline::{
@@ -23,7 +22,6 @@ use crate::texture::{Image, ImageId, Images};
 
 pub(crate) struct RenderState {
     pub cameras: HashMap<CameraId, Camera>,
-    pub camera_buffers: HashMap<CameraId, CameraBuffer>,
     pub objects: HashMap<ObjectId, Object>,
     /// object transform buffers
     pub object_buffers: HashMap<ObjectId, BindGroup>,
@@ -90,7 +88,6 @@ impl RenderState {
             materials_queued: HashMap::new(),
             images: imgs,
             meshes_queued: HashMap::new(),
-            camera_buffers: HashMap::new(),
             object_buffers: HashMap::new(),
             directional_lights: HashMap::new(),
             point_lights: HashMap::new(),
@@ -206,19 +203,9 @@ impl RenderState {
 
         for event in self.events.drain(..) {
             match event {
-                Event::CreateCamera(id, camera) => {
-                    let buffer = CameraBuffer::new(
-                        camera.transform,
-                        camera.projection,
-                        device,
-                        camera.target,
-                    );
-
-                    self.camera_buffers.insert(id, buffer);
-                }
+                Event::CreateCamera(_id, _camera) => (),
                 Event::DestroyCamera(id) => {
                     self.cameras.remove(&id);
-                    self.camera_buffers.remove(&id);
                 }
                 Event::CreateObject(id, object) => {
                     let buffer = update_transform_buffer(object.transform, device);


### PR DESCRIPTION
`CameraBuffer` is unnecessary since the camera matrix is already provided via push constants.