### PR TITLE
Remove `const_delay` from initial handshake

### DIFF
--- a/game_client/src/net/socket.rs
+++ b/game_client/src/net/socket.rs
@@ -39,13 +39,8 @@ where
 
             let (stream_tx, stream_rx) = tokio::sync::mpsc::channel(4096);
             let stream = UdpSocketStream::new(stream_rx, socket.clone(), addr);
-            let (mut conn, handle) = Connection::<_, Connect>::new(
-                stream,
-                ControlFrame(0),
-                ControlFrame(0),
-                local_addr,
-                addr,
-            );
+            let (mut conn, handle) =
+                Connection::<_, Connect>::new(stream, ControlFrame(0), local_addr, addr);
 
             tracing::info!("connecting to {:?}", addr);
 

--- a/game_net/src/conn.rs
+++ b/game_net/src/conn.rs
@@ -90,9 +90,6 @@ where
     /// Starting control frame.
     start_control_frame: ControlFrame,
 
-    /// Local constant buffer in control frames.
-    const_delay: u16,
-
     _mode: PhantomData<fn() -> M>,
 
     #[cfg(debug_assertions)]
@@ -124,7 +121,6 @@ where
     pub fn new(
         stream: S,
         control_frame: ControlFrame,
-        const_delay: ControlFrame,
         local_addr: SocketAddr,
         remote_addr: SocketAddr,
     ) -> (Self, ConnectionHandle) {
@@ -151,8 +147,6 @@ where
             start_control_frame: control_frame,
 
             _mode: PhantomData,
-
-            const_delay: const_delay.0,
 
             max_data_size: 512,
             reassembly_buffer: ReassemblyBuffer::new(MAX_REASSEMBLY_SIZE),
@@ -437,8 +431,6 @@ where
                         mtu: 1500,
                         flow_window: 8192,
                         initial_sequence: self.next_local_sequence,
-                        const_delay: self.const_delay,
-                        resv0: 0,
                     }),
                 };
 
@@ -495,8 +487,6 @@ where
                         mtu: 1500,
                         flow_window: 8192,
                         initial_sequence,
-                        const_delay: self.const_delay,
-                        resv0: 0,
                     }),
                 };
 
@@ -535,8 +525,6 @@ where
                         mtu: 1500,
                         flow_window: 8192,
                         initial_sequence: self.next_local_sequence,
-                        const_delay: self.const_delay,
-                        resv0: 0,
                     }),
                 };
 
@@ -685,8 +673,6 @@ where
                 mtu: 1500,
                 flow_window: 8192,
                 initial_sequence,
-                const_delay: self.const_delay,
-                resv0: 0,
             }),
         };
 
@@ -766,8 +752,6 @@ where
                 mtu: 1500,
                 flow_window: 8192,
                 initial_sequence: Sequence::new(0),
-                const_delay: 0,
-                resv0: 0,
             }),
         };
 

--- a/game_net/src/proto/handshake.rs
+++ b/game_net/src/proto/handshake.rs
@@ -26,8 +26,6 @@ use super::{Decode, Encode, Error};
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// | ISN                                                           |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/// | Const Delay                   | Reserved                      |
-/// +-+-++-+-+-+-+-+-+-++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Copy, Clone, Debug, Encode, Decode)]
 pub struct Handshake {
@@ -37,9 +35,6 @@ pub struct Handshake {
     pub mtu: u16,
     pub flow_window: u16,
     pub initial_sequence: Sequence,
-    /// Constant delay in control frames.
-    pub const_delay: u16,
-    pub resv0: u16,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, thiserror::Error)]

--- a/game_net/tests/conn.rs
+++ b/game_net/tests/conn.rs
@@ -29,8 +29,6 @@ async fn handshake() {
             mtu: 1500,
             flow_window: 8192,
             initial_sequence,
-            const_delay: 0,
-            resv0: 0,
         }),
     })
     .unwrap();
@@ -57,8 +55,6 @@ async fn handshake() {
             mtu: 1500,
             flow_window: 8192,
             initial_sequence,
-            const_delay: 0,
-            resv0: 0,
         }),
     })
     .unwrap();
@@ -85,7 +81,6 @@ fn create_listen_connection() -> (
 
     let (conn, handle) = Connection::<_, Listen>::new(
         stream,
-        ControlFrame(0),
         ControlFrame(0),
         SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
@@ -114,8 +109,6 @@ async fn do_handshake(tx: &mut mpsc::Sender<Packet>, rx: &mut mpsc::Receiver<Pac
             mtu: 1500,
             flow_window: 8192,
             initial_sequence,
-            const_delay: 0,
-            resv0: 0,
         }),
     })
     .unwrap();
@@ -142,8 +135,6 @@ async fn do_handshake(tx: &mut mpsc::Sender<Packet>, rx: &mut mpsc::Receiver<Pac
             mtu: 1500,
             flow_window: 8192,
             initial_sequence,
-            const_delay: 0,
-            resv0: 0,
         }),
     })
     .unwrap();

--- a/game_server/src/server.rs
+++ b/game_server/src/server.rs
@@ -167,7 +167,6 @@ impl ConnectionPool {
         let (conn, handle) = Connection::<_, Listen>::new(
             stream,
             self.state.control_frame.get(),
-            ControlFrame(0),
             key.local_addr,
             key.remote_addr,
         );


### PR DESCRIPTION
The constant delay is not used by either client and server is a left over from a previous implementation of client-side prediction.