### PR TITLE
Allow shared access to `CommandQueue`

### DIFF
--- a/game_core_pipeline/src/passes/forward.rs
+++ b/game_core_pipeline/src/passes/forward.rs
@@ -46,7 +46,7 @@ pub(super) struct ForwardPass {
 
 impl ForwardPass {
     pub(super) fn new(
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         state: Arc<Mutex<State>>,
         hdr_texture_slot: SlotLabel,
     ) -> Self {
@@ -137,12 +137,7 @@ impl ForwardPass {
         }
     }
 
-    fn update_depth_stencil(
-        &self,
-        queue: &mut CommandQueue<'_>,
-        target: RenderTarget,
-        size: UVec2,
-    ) {
+    fn update_depth_stencil(&self, queue: &CommandQueue<'_>, target: RenderTarget, size: UVec2) {
         let mut depth_stencils = self.depth_stencils.write();
         if let Some(texture) = depth_stencils.get(&target) {
             // Texture size unchanged, no need to recreate.
@@ -356,7 +351,7 @@ struct BuildForwardPipeline {
 impl PipelineBuilder for BuildForwardPipeline {
     fn build(
         &self,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         shaders: &[Shader],
         format: TextureFormat,
     ) -> Pipeline {

--- a/game_core_pipeline/src/passes/mod.rs
+++ b/game_core_pipeline/src/passes/mod.rs
@@ -41,7 +41,7 @@ pub const FINAL_RENDER_PASS: NodeLabel = NodeLabel::new("FINAL_RENDER_PASS");
 
 const HDR_TEXTURE: SlotLabel = SlotLabel::new("HDR_TEXTURE");
 
-pub(crate) fn init(graph: &mut RenderGraph, queue: &mut CommandQueue<'_>, events: Receiver<Event>) {
+pub(crate) fn init(graph: &mut RenderGraph, queue: &CommandQueue<'_>, events: Receiver<Event>) {
     let state = Arc::new(Mutex::new(State::new(queue)));
 
     let update_pass = UpdatePass::new(queue, state.clone(), events);
@@ -98,7 +98,7 @@ struct State {
 }
 
 impl State {
-    fn new(queue: &mut CommandQueue<'_>) -> Self {
+    fn new(queue: &CommandQueue<'_>) -> Self {
         let mesh_descriptor_layout = queue.create_descriptor_set_layout(&DescriptorSetDescriptor {
             bindings: &[
                 // POSITIONS
@@ -195,7 +195,7 @@ struct DefaultTextures {
 }
 
 impl DefaultTextures {
-    fn new(queue: &mut CommandQueue<'_>, textures: &mut TextureSlab) -> Self {
+    fn new(queue: &CommandQueue<'_>, textures: &mut TextureSlab) -> Self {
         let [base_color, normal, metallic_roughness, specular_glossiness] = [
             // Base color: white
             (TextureFormat::Rgba8UnormSrgb, [255, 255, 255, 255]),

--- a/game_core_pipeline/src/passes/post_process.rs
+++ b/game_core_pipeline/src/passes/post_process.rs
@@ -27,7 +27,7 @@ pub struct PostProcessPass {
 }
 
 impl PostProcessPass {
-    pub fn new(queue: &mut CommandQueue<'_>, src: SlotLabel, dst: SlotLabel) -> Self {
+    pub fn new(queue: &CommandQueue<'_>, src: SlotLabel, dst: SlotLabel) -> Self {
         let bind_group_layout =
             queue.create_descriptor_set_layout(&DescriptorSetLayoutDescriptor {
                 bindings: &[
@@ -123,7 +123,7 @@ struct PostProcessPipelineBuilder {
 impl PipelineBuilder for PostProcessPipelineBuilder {
     fn build(
         &self,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         shaders: &[Shader],
         format: TextureFormat,
     ) -> Pipeline {

--- a/game_core_pipeline/src/passes/state/mesh.rs
+++ b/game_core_pipeline/src/passes/state/mesh.rs
@@ -28,7 +28,7 @@ pub struct MeshState {
 }
 
 impl MeshState {
-    pub fn new(queue: &mut CommandQueue<'_>) -> Self {
+    pub fn new(queue: &CommandQueue<'_>) -> Self {
         Self {
             positions: SubAllocatedGrowableBuffer::new(queue, BufferUsage::STORAGE),
             normals: SubAllocatedGrowableBuffer::new(queue, BufferUsage::STORAGE),
@@ -42,7 +42,7 @@ impl MeshState {
         }
     }
 
-    pub fn create_mesh(&mut self, queue: &mut CommandQueue<'_>, mesh: &Mesh) -> MeshStrategyMeshId {
+    pub fn create_mesh(&mut self, queue: &CommandQueue<'_>, mesh: &Mesh) -> MeshStrategyMeshId {
         let _span = trace_span!("MeshState::create_mesh").entered();
 
         let indices = mesh.indicies().unwrap().into_u32();

--- a/game_core_pipeline/src/passes/update.rs
+++ b/game_core_pipeline/src/passes/update.rs
@@ -39,7 +39,7 @@ pub(super) struct UpdatePass {
 
 impl UpdatePass {
     pub(super) fn new(
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         state: Arc<Mutex<State>>,
         events: Receiver<Event>,
     ) -> Self {
@@ -186,7 +186,7 @@ impl Node for UpdatePass {
 }
 
 fn create_image(
-    queue: &mut CommandQueue<'_>,
+    queue: &CommandQueue<'_>,
     textures: &mut TextureSlab,
     mipgen: &MipMapGenerator,
     image: &MipImage,

--- a/game_gizmos/src/render/pipeline.rs
+++ b/game_gizmos/src/render/pipeline.rs
@@ -31,7 +31,7 @@ pub struct GizmoPipeline {
 }
 
 impl GizmoPipeline {
-    pub fn new(queue: &mut CommandQueue<'_>) -> Self {
+    pub fn new(queue: &CommandQueue<'_>) -> Self {
         let bind_group_layout =
             queue.create_descriptor_set_layout(&DescriptorSetLayoutDescriptor {
                 bindings: &[
@@ -75,7 +75,7 @@ struct GizmoPipelineBuilder {
 impl PipelineBuilder for GizmoPipelineBuilder {
     fn build(
         &self,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         shaders: &[Shader],
         format: TextureFormat,
     ) -> Pipeline {
@@ -113,7 +113,7 @@ pub struct GizmoPass {
 
 impl GizmoPass {
     pub(crate) fn new(
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         elements: Arc<RwLock<Vec<DrawCommand>>>,
         camera: Arc<Mutex<Option<Camera>>>,
     ) -> Self {

--- a/game_render/src/buffer/block.rs
+++ b/game_render/src/buffer/block.rs
@@ -102,7 +102,7 @@ impl BlockBuffer {
         }
     }
 
-    pub fn buffer(&mut self, queue: &mut CommandQueue<'_>) -> &Buffer {
+    pub fn buffer(&mut self, queue: &CommandQueue<'_>) -> &Buffer {
         let buffer = self.buffer.get_or_insert_with(|| {
             let size = (self.block_size * self.buffer_size.max(1)) as u64;
 

--- a/game_render/src/buffer/slab.rs
+++ b/game_render/src/buffer/slab.rs
@@ -58,7 +58,7 @@ where
             .compact(|src, dst| rekey(SlabIndex(src), SlabIndex(dst)));
     }
 
-    pub fn buffer(&mut self, queue: &mut CommandQueue<'_>) -> &Buffer {
+    pub fn buffer(&mut self, queue: &CommandQueue<'_>) -> &Buffer {
         self.buffer.buffer(queue)
     }
 }
@@ -107,7 +107,7 @@ where
         });
     }
 
-    pub fn buffer(&mut self, queue: &mut CommandQueue<'_>) -> &Buffer {
+    pub fn buffer(&mut self, queue: &CommandQueue<'_>) -> &Buffer {
         self.buffer.buffer(queue)
     }
 }

--- a/game_render/src/buffer/suballocated.rs
+++ b/game_render/src/buffer/suballocated.rs
@@ -23,7 +23,7 @@ where
     T: NoUninit,
     A: GrowableAllocator,
 {
-    pub fn new(queue: &mut CommandQueue<'_>, usage: BufferUsage) -> Self {
+    pub fn new(queue: &CommandQueue<'_>, usage: BufferUsage) -> Self {
         let buffer = queue.create_buffer(&BufferDescriptor {
             size: 1,
             usage: usage | BufferUsage::TRANSFER_SRC | BufferUsage::TRANSFER_DST,
@@ -42,7 +42,7 @@ where
     /// Inserts a new array of values into the buffer.
     ///
     /// Returns an index to the first value. The values are densly packed in the buffer.
-    pub fn insert(&mut self, queue: &mut CommandQueue<'_>, value: &[T]) -> u64 {
+    pub fn insert(&mut self, queue: &CommandQueue<'_>, value: &[T]) -> u64 {
         let bytes = bytemuck::must_cast_slice(value);
 
         let layout = Layout::array::<T>(value.len()).unwrap();
@@ -94,7 +94,7 @@ where
         }
     }
 
-    fn grow(&mut self, queue: &mut CommandQueue<'_>, size: usize) {
+    fn grow(&mut self, queue: &CommandQueue<'_>, size: usize) {
         let old_size = self.buffer.size();
         let new_size =
             u64::max(old_size << 1, old_size + size.next_power_of_two() as u64).next_power_of_two();

--- a/game_render/src/forward.rs
+++ b/game_render/src/forward.rs
@@ -195,7 +195,7 @@ pub struct ForwardPipelineBuilder {
 impl PipelineBuilder for ForwardPipelineBuilder {
     fn build(
         &self,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         shaders: &[Shader],
         format: TextureFormat,
     ) -> Pipeline {

--- a/game_render/src/graph.rs
+++ b/game_render/src/graph.rs
@@ -43,7 +43,7 @@ pub trait Node: Send + Sync + 'static {
 /// Context provided to render a [`Node`].
 pub struct RenderContext<'a, 'b> {
     pub render_target: RenderTarget,
-    pub queue: &'b mut CommandQueue<'a>,
+    pub queue: &'b CommandQueue<'a>,
     pub(crate) resource_permissions: &'a HashMap<SlotLabel, SlotFlags>,
     pub(crate) resources: &'b mut HashMap<SlotLabel, SlotValueInner<'a>>,
 }

--- a/game_render/src/lib.rs
+++ b/game_render/src/lib.rs
@@ -221,7 +221,7 @@ impl Renderer {
 
     pub fn with_command_queue_and_graph<F, R>(&mut self, f: F) -> R
     where
-        F: FnOnce(&mut RenderGraph, &mut CommandQueue<'_>) -> R,
+        F: FnOnce(&mut RenderGraph, &CommandQueue<'_>) -> R,
     {
         if let Some(parker) = self.parker.take() {
             parker.park();
@@ -229,10 +229,10 @@ impl Renderer {
 
         // SAFETY: We have waited until the render thread is idle.
         // This means we are allowed to access all shared resources.
-        let mut scheduler = unsafe { self.render_thread.shared.scheduler.borrow_mut() };
+        let scheduler = unsafe { self.render_thread.shared.scheduler.borrow_mut() };
         let mut graph = unsafe { self.render_thread.shared.graph.borrow_mut() };
-        let mut queue = scheduler.queue();
-        f(&mut graph, &mut queue)
+        let queue = scheduler.queue();
+        f(&mut graph, &queue)
     }
 
     pub fn create_render_texture(&mut self, texture: RenderTexture) -> RenderImageId {

--- a/game_render/src/mipmap.rs
+++ b/game_render/src/mipmap.rs
@@ -26,7 +26,7 @@ pub struct MipMapGenerator {
 }
 
 impl MipMapGenerator {
-    pub fn new(queue: &mut CommandQueue<'_>) -> Self {
+    pub fn new(queue: &CommandQueue<'_>) -> Self {
         let layout = queue.create_descriptor_set_layout(&DescriptorSetLayoutDescriptor {
             bindings: &[
                 DescriptorBinding {
@@ -66,7 +66,7 @@ impl MipMapGenerator {
         }
     }
 
-    pub fn generate_mipmaps(&self, queue: &mut CommandQueue<'_>, texture: &Texture) {
+    pub fn generate_mipmaps(&self, queue: &CommandQueue<'_>, texture: &Texture) {
         let _span = trace_span!("MipMapGenerator::generate_mipmaps").entered();
 
         let pipeline = self.pipelines.get(queue, texture.format());
@@ -123,7 +123,7 @@ struct BlitPipelineBuilder {
 impl PipelineBuilder for BlitPipelineBuilder {
     fn build(
         &self,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         shaders: &[Shader],
         format: TextureFormat,
     ) -> Pipeline {

--- a/game_render/src/passes/forward_pass.rs
+++ b/game_render/src/passes/forward_pass.rs
@@ -80,7 +80,7 @@ impl Node for ForwardPass {
 
         for camera in state.cameras.values() {
             if camera.target == ctx.render_target {
-                self.update_depth_stencil(ctx.render_target, size, &mut ctx.queue);
+                self.update_depth_stencil(ctx.render_target, size, &ctx.queue);
 
                 let scene = state.scenes.get(&camera.scene).unwrap();
                 self.render_camera_target(&state, &scene, camera, ctx, size);
@@ -95,12 +95,7 @@ impl Node for ForwardPass {
 }
 
 impl ForwardPass {
-    fn update_depth_stencil(
-        &self,
-        target: RenderTarget,
-        size: UVec2,
-        queue: &mut CommandQueue<'_>,
-    ) {
+    fn update_depth_stencil(&self, target: RenderTarget, size: UVec2, queue: &CommandQueue<'_>) {
         let mut depth_stencils = self.depth_stencils.lock();
 
         if let Some(texture) = depth_stencils.get(&target) {
@@ -332,7 +327,7 @@ struct Scene {
 }
 
 impl Scene {
-    fn new(queue: &mut CommandQueue<'_>) -> Self {
+    fn new(queue: &CommandQueue<'_>) -> Self {
         let directional_lights = queue.create_buffer_init(&BufferInitDescriptor {
             contents: DynamicBuffer::<DirectionalLightUniform>::new().as_bytes(),
             usage: BufferUsage::STORAGE,
@@ -391,7 +386,7 @@ impl ForwardState {
         &mut self,
         resources: &Resources,
         events: &mut Vec<Event>,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         mesh_bind_group_layout: &DescriptorSetLayout,
         material_bind_group_layout: &DescriptorSetLayout,
         object_bind_group_layout: &DescriptorSetLayout,
@@ -659,7 +654,7 @@ impl ForwardState {
 }
 
 fn upload_mesh(
-    queue: &mut CommandQueue<'_>,
+    queue: &CommandQueue<'_>,
     mesh: &Mesh,
     bind_group_layout: &DescriptorSetLayout,
 ) -> (DescriptorSet, IndexBuffer) {
@@ -752,7 +747,7 @@ fn upload_mesh(
 }
 
 fn create_material(
-    queue: &mut CommandQueue<'_>,
+    queue: &CommandQueue<'_>,
     bind_group_layout: &DescriptorSetLayout,
     default_textures: &DefaultTextures,
     bound_textures: &mut HashMap<ImageId, Texture>,
@@ -842,7 +837,7 @@ fn create_material(
 }
 
 fn upload_material_texture(
-    queue: &mut CommandQueue<'_>,
+    queue: &CommandQueue<'_>,
     mipmap_generator: &MipMapGenerator,
     image: &Image,
 ) -> Texture {

--- a/game_render/src/passes/post_process.rs
+++ b/game_render/src/passes/post_process.rs
@@ -125,7 +125,7 @@ struct PostProcessPipelineBuilder {
 impl PipelineBuilder for PostProcessPipelineBuilder {
     fn build(
         &self,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         shaders: &[Shader],
         format: TextureFormat,
     ) -> Pipeline {

--- a/game_render/src/pipeline_cache.rs
+++ b/game_render/src/pipeline_cache.rs
@@ -43,7 +43,7 @@ where
     /// be created using the [`PipelineBuilder`].
     pub fn get<'a, 'b>(
         &'a self,
-        queue: &'b mut CommandQueue<'_>,
+        queue: &'b CommandQueue<'_>,
         format: TextureFormat,
     ) -> PipelineRef<'a> {
         let mut pipelines = self.pipelines.read();
@@ -152,7 +152,7 @@ pub trait PipelineBuilder {
     /// Returns a new pipeline with the requested [`TextureFormat`].
     fn build(
         &self,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         shaders: &[Shader],
         format: TextureFormat,
     ) -> Pipeline;

--- a/game_ui/src/render/pipeline.rs
+++ b/game_ui/src/render/pipeline.rs
@@ -44,11 +44,11 @@ struct UiPipeline {
 }
 
 impl UiPipeline {
-    pub fn new(queue: &mut CommandQueue<'_>) -> Self {
+    pub fn new(queue: &CommandQueue<'_>) -> Self {
         Self::new_with_capacity(queue, DEFAULT_TEXTURE_CAPACITY)
     }
 
-    fn new_with_capacity(queue: &mut CommandQueue<'_>, capacity: NonZeroU32) -> Self {
+    fn new_with_capacity(queue: &CommandQueue<'_>, capacity: NonZeroU32) -> Self {
         let descriptor_set_layout =
             queue.create_descriptor_set_layout(&DescriptorSetLayoutDescriptor {
                 bindings: &[
@@ -109,7 +109,7 @@ struct UiPipelineBuilder {
 impl PipelineBuilder for UiPipelineBuilder {
     fn build(
         &self,
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         shaders: &[Shader],
         format: TextureFormat,
     ) -> Pipeline {
@@ -161,7 +161,7 @@ pub struct UiPass {
 
 impl UiPass {
     pub(super) fn new(
-        queue: &mut CommandQueue<'_>,
+        queue: &CommandQueue<'_>,
         elems: Arc<RwLock<HashMap<RenderTarget, SurfaceDrawCommands>>>,
     ) -> Self {
         let index_buffer = queue.create_buffer_init(&BufferInitDescriptor {
@@ -180,12 +180,7 @@ impl UiPass {
         }
     }
 
-    fn update_buffers(
-        &self,
-        target: RenderTarget,
-        queue: &mut CommandQueue<'_>,
-        viewport_size: UVec2,
-    ) {
+    fn update_buffers(&self, target: RenderTarget, queue: &CommandQueue<'_>, viewport_size: UVec2) {
         let mut vertex_buffer = self.vertex_buffer.lock();
         let mut texture_buffer = self.textures.lock();
         let mut instance_count = self.instance_count.lock();
@@ -338,7 +333,7 @@ const INDICES: &[u16] = &[0, 1, 2, 3, 0, 2];
 fn create_element(
     cmd: &DrawCommand,
     viewport_size: UVec2,
-    queue: &mut CommandQueue<'_>,
+    queue: &CommandQueue<'_>,
 ) -> GpuDrawCommandState {
     let _span = trace_span!("create_element").entered();
 


### PR DESCRIPTION
The inner resources were already threadsafe and allowing shared acess to `CommandQueue` allows for more optimizations (e.g. parallel recording) in the future.