### PR TITLE
Replace `tracing-tracy` with a manual `Layer` based on `tracy-client`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,8 @@ allow = [
 ]
 
 exceptions = [
-    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+    { allow = ["Unicode-DFS-2016", "Unicode-3.0"], name = "unicode-ident" },
+    { allow = ["NCSA"], name = "libfuzzer-sys" },
 
     # Only for us.
     { allow = ["GPL-3.0"], name = "game_ai" },

--- a/game_core/src/logger.rs
+++ b/game_core/src/logger.rs
@@ -21,9 +21,7 @@ static LOGGER: OnceLock<Logger> = OnceLock::new();
 pub fn init() {
     let layer = tracing_subscriber::registry();
     #[cfg(feature = "tracy")]
-    let layer = layer.with(game_tracing::ProfilingLayer::new(
-        game_tracing::ProfilerConfig::default(),
-    ));
+    let layer = layer.with(game_tracing::TracyLayer::new());
 
     let logger = LOGGER.get_or_init(Logger::new);
     let layer = layer.with(logger);

--- a/game_tracing/Cargo.toml
+++ b/game_tracing/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-or-later"
 
 [features]
 default = []
-tracy = ["tracing-tracy", "tracy-client"]
+tracy = ["tracy-client", "tracy-client-sys"]
 
 [lints]
 workspace = true
@@ -18,12 +18,10 @@ tracing = "0.1.40"
 
 tracing-subscriber = "0.3.18"
 
-[dependencies.tracing-tracy]
-version = "=0.11.1"
-optional = true
+tracy-client-sys = { version = "=0.25.0", optional = true }
 
 [dependencies.tracy-client]
-version = "=0.17.1"
+version = "=0.18.1"
 optional = true
 default-features = false
 features = [
@@ -35,4 +33,6 @@ features = [
     "callstack-inlines",
     "code-transfer",
     "broadcast",
+    "ondemand",
+    "sampling",
 ]

--- a/game_tracing/src/layer.rs
+++ b/game_tracing/src/layer.rs
@@ -1,28 +1,106 @@
-use tracing::Metadata;
-use tracing_tracy::{Config, DefaultConfig, TracyLayer};
+use std::cell::RefCell;
+use std::fmt::{Debug, Write};
+
+use tracing::field::{Field, Visit};
+use tracing::span::Id;
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
 use tracy_client::Client;
 
-pub type ProfilingLayer = TracyLayer<ProfilerConfig>;
+thread_local! {
+    // Spans are !Send so we can keep them on the current thread.
+    // Spans are also ordered, so we can use a Vec instead of a HashMap.
+    static LOCAL_SPANS: RefCell<Vec<(tracy_client::Span, u64)>> = RefCell::new(Vec::new());
+    // To prevent allocator pressure we keep the string buffer alive
+    // for each thread.
+    static STRING_BUFFER: RefCell<String> = RefCell::new(String::new());
+}
 
-#[derive(Default)]
-pub struct ProfilerConfig(DefaultConfig);
+pub struct TracyLayer {
+    client: Client,
+}
 
-impl Config for ProfilerConfig {
-    type Formatter = <DefaultConfig as Config>::Formatter;
+impl TracyLayer {
+    pub fn new() -> Self {
+        Self {
+            client: Client::start(),
+        }
+    }
+}
 
-    fn formatter(&self) -> &Self::Formatter {
-        self.0.formatter()
+impl<S> Layer<S> for TracyLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        STRING_BUFFER.with_borrow_mut(|buf| {
+            let mut visitor = Visitor { buf };
+            event.record(&mut visitor);
+
+            if visitor.buf.len() > u16::MAX as usize {
+                let prefix = "[TRUNCATED] ";
+                visitor.buf.truncate(u16::MAX as usize - prefix.len() - 1);
+                visitor.buf.insert_str(0, prefix);
+            }
+
+            self.client.message(&visitor.buf, 0);
+
+            buf.clear();
+        });
     }
 
-    fn format_fields_in_zone_name(&self) -> bool {
-        false
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+
+        let file = span.metadata().file().unwrap_or("???");
+        let line = span.metadata().line().unwrap_or(0);
+        let name = span.name();
+
+        let span = self
+            .client
+            .clone()
+            .span_alloc(Some(name), "", file, line, 0);
+
+        LOCAL_SPANS.with_borrow_mut(|spans| {
+            spans.push((span, id.into_u64()));
+        });
     }
 
-    fn stack_depth(&self, metadata: &Metadata<'_>) -> u16 {
-        self.0.stack_depth(metadata)
+    fn on_exit(&self, id: &Id, _ctx: Context<'_, S>) {
+        LOCAL_SPANS.with_borrow_mut(|spans| {
+            if let Some((span, span_id)) = spans.pop() {
+                if span_id != id.into_u64() {
+                    tracing::warn!("tracing spans are out of order!");
+                }
+
+                drop(span);
+            }
+        });
+    }
+}
+
+#[derive(Debug)]
+struct Visitor<'a> {
+    buf: &'a mut String,
+}
+
+impl<'a> Visit for Visitor<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if self.buf.is_empty() {
+            write!(self.buf, "{} = {}", field.name(), value).ok();
+        } else {
+            write!(self.buf, ", {} = {}", field.name(), value).ok();
+        }
     }
 
-    fn on_error(&self, client: &Client, error: &'static str) {
-        self.0.on_error(client, error);
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        if self.buf.is_empty() {
+            write!(self.buf, "{} = {:?}", field.name(), value).ok();
+        } else {
+            write!(self.buf, ", {} = {:?}", field.name(), value).ok();
+        }
     }
 }

--- a/game_tracing/src/lib.rs
+++ b/game_tracing/src/lib.rs
@@ -8,7 +8,7 @@ mod layer;
 #[cfg(feature = "tracy")]
 pub use allocator::ProfiledAllocator;
 #[cfg(feature = "tracy")]
-pub use layer::{ProfilerConfig, ProfilingLayer};
+pub use layer::TracyLayer;
 #[cfg(feature = "tracy")]
 pub use tracy_client::Client;
 


### PR DESCRIPTION
`tracing-tracy` is the cause of many version compatability issues on upgrades even using pinned version. The manual `Layer` implementation is based on `tracy-client` and as such is always up to date.