### PR TITLE
Rework how `ImageDataLayout` is described when writing to GPU textures

### DIFF
--- a/game_core_pipeline/src/passes/mod.rs
+++ b/game_core_pipeline/src/passes/mod.rs
@@ -235,10 +235,7 @@ impl DefaultTextures {
                     mip_level: 0,
                 },
                 &data,
-                ImageDataLayout {
-                    bytes_per_row: 4,
-                    rows_per_image: 1,
-                },
+                ImageDataLayout { format },
             );
 
             textures.insert(texture.create_view(&TextureViewDescriptor::default()))

--- a/game_core_pipeline/src/passes/update.rs
+++ b/game_core_pipeline/src/passes/update.rs
@@ -224,9 +224,6 @@ fn create_image(
     });
 
     for (mip_level, mip) in image.mips().iter().enumerate() {
-        let bytes_per_row = u32::max(1, mip.width() / 4) * mip.format().bytes_per_block();
-        let rows_per_image = u32::max(1, mip.height() / 4);
-
         queue.write_texture(
             TextureRegion {
                 texture: &texture,
@@ -234,8 +231,7 @@ fn create_image(
             },
             mip.as_bytes(),
             ImageDataLayout {
-                bytes_per_row,
-                rows_per_image,
+                format: mip.format(),
             },
         );
     }

--- a/game_render/src/backend/vulkan.rs
+++ b/game_render/src/backend/vulkan.rs
@@ -2802,6 +2802,8 @@ vk_enum! {
 
 vk_enum! {
     TextureFormat => vk::Format,
+    TextureFormat::Rgb8Unorm => vk::Format::R8G8B8_UNORM,
+    TextureFormat::Rgb8UnormSrgb => vk::Format::R8G8B8_SRGB,
     TextureFormat::Rgba8Unorm => vk::Format::R8G8B8A8_UNORM,
     TextureFormat::Rgba8UnormSrgb => vk::Format::R8G8B8A8_SRGB,
     TextureFormat::Bgra8Unorm => vk::Format::B8G8R8A8_UNORM,
@@ -3217,15 +3219,15 @@ impl<'a> CommandEncoder<'a> {
         assert_ne!(dst.size.x, 0);
         assert_ne!(dst.size.y, 0);
 
-        let bytes_to_copy = src.layout.bytes_per_row as u64 * src.layout.rows_per_image as u64;
-        assert!(src.buffer.size > src.offset);
-        assert!(src.buffer.size - src.offset >= bytes_to_copy);
-
         assert!(mip_level < dst.mip_levels);
 
         // Use the size of the selected mip level.
         // https://docs.vulkan.org/spec/latest/chapters/resources.html#resources-image-mip-level-sizing
         let dst_size = UVec2::max(UVec2::ONE, dst.size >> mip_level);
+
+        let bytes_to_copy = src.layout.format.storage_size(dst_size) as u64;
+        assert!(src.buffer.size > src.offset);
+        assert!(src.buffer.size - src.offset >= bytes_to_copy);
 
         let aspect_mask = if dst.format.is_depth() {
             vk::ImageAspectFlags::DEPTH

--- a/game_render/src/passes/forward_pass.rs
+++ b/game_render/src/passes/forward_pass.rs
@@ -284,10 +284,7 @@ impl DefaultTextures {
                     mip_level: 0,
                 },
                 &data,
-                ImageDataLayout {
-                    bytes_per_row: 4,
-                    rows_per_image: 1,
-                },
+                ImageDataLayout { format },
             );
 
             texture
@@ -861,8 +858,7 @@ fn upload_material_texture(
         },
         image.as_bytes(),
         ImageDataLayout {
-            bytes_per_row: 4 * image.width(),
-            rows_per_image: image.height(),
+            format: image.format(),
         },
     );
 

--- a/game_render/src/texture/image.rs
+++ b/game_render/src/texture/image.rs
@@ -91,10 +91,11 @@ impl Image {
     }
 
     fn validate_size(&self) {
-        // Bytes for a 4x4 block.
-        let block_size = self.format.bytes_per_block();
-        let size = u32::max(1, self.width / 4) * u32::max(1, self.height / 4) * block_size;
-        assert_eq!(size as usize, self.bytes.len());
+        assert_eq!(
+            self.format
+                .storage_size(UVec2::new(self.width, self.height)),
+            self.bytes.len()
+        );
     }
 }
 

--- a/game_ui/src/render/pipeline.rs
+++ b/game_ui/src/render/pipeline.rs
@@ -360,8 +360,7 @@ fn create_element(
         },
         &cmd.image,
         ImageDataLayout {
-            rows_per_image: 4 * cmd.image.width(),
-            bytes_per_row: cmd.image.height(),
+            format: TextureFormat::Rgba8UnormSrgb,
         },
     );
 


### PR DESCRIPTION
Replace the confusing and error-prone `bytes_per_row` and `rows_per_image` properties with a `TextureFormat` and assume data is always densly packed.