### PR TITLE
Keep all physical resources in the `Executor`

### DIFF
--- a/game_render/src/api/executor.rs
+++ b/game_render/src/api/executor.rs
@@ -7,7 +7,8 @@ use game_common::collections::scratch_buffer::ScratchBuffer;
 use game_tracing::trace_span;
 use hashbrown::HashMap;
 
-use crate::backend::allocator::BufferAlloc;
+use crate::backend::allocator::{BufferAlloc, GeneralPurposeAllocator, TextureAlloc, UsageFlags};
+use crate::backend::descriptors::AllocatedDescriptorSet;
 use crate::backend::vulkan::{self, CommandEncoder, TextureView};
 use crate::backend::{
     AccessFlags, BufferBarrier, CopyBuffer, DrawIndexedIndirectCommand, DrawIndirectCommand,
@@ -16,10 +17,7 @@ use crate::backend::{
     WriteDescriptorBinding, WriteDescriptorResource, WriteDescriptorResources,
 };
 
-use super::commands::{
-    Command, CommandRef, ComputeCommand, ComputePassCmd, CopyBufferToBuffer, CopyBufferToTexture,
-    CopyTextureToTexture, RenderPassCmd, WriteBuffer,
-};
+use super::commands::{Command, CommandRef, ComputeCommand, ComputePassCmd, RenderPassCmd};
 use super::queries::{ManagedQueryPool, QueryObject, QueryPoolSet};
 use super::resources::DescriptorSetResource;
 use super::scheduler::{Barrier, Step};
@@ -28,234 +26,247 @@ use super::{
     SamplerId, TextureId,
 };
 
-pub(super) fn execute(
-    resources: &Resources,
-    steps: Vec<Step<&CommandRef<'_>, ResourceId>>,
-    encoder: &mut CommandEncoder<'_>,
-    queries: &QueryPoolSet,
-) -> TemporaryResources {
-    let _span = trace_span!("execute").entered();
+#[derive(Debug)]
+pub(super) struct Executor {
+    allocator: GeneralPurposeAllocator,
+    buffers: HashMap<BufferId, BufferAlloc>,
+    textures: HashMap<TextureId, TextureData>,
+    descriptor_sets: HashMap<DescriptorSetId, DescriptorSetInner>,
+}
 
-    let mut render_passes = 0;
-    let mut compute_passes = 0;
+impl Executor {
+    pub fn new(allocator: GeneralPurposeAllocator) -> Self {
+        Self {
+            allocator,
+            buffers: HashMap::new(),
+            textures: HashMap::new(),
+            descriptor_sets: HashMap::new(),
+        }
+    }
 
-    for step in &steps {
-        match step {
-            Step::Node(cmd) => match cmd.as_ref() {
-                Command::RenderPass(_) => {
-                    render_passes += 1;
-                }
-                Command::ComputePass(_) => {
-                    compute_passes += 1;
-                }
+    pub fn execute(
+        &mut self,
+        resources: &Resources,
+        steps: Vec<Step<&CommandRef<'_>, ResourceId>>,
+        encoder: &mut CommandEncoder<'_>,
+        queries: &QueryPoolSet,
+    ) -> TemporaryResources {
+        let _span = trace_span!("Executor::execute").entered();
+
+        let mut render_passes = 0;
+        let mut compute_passes = 0;
+
+        for step in &steps {
+            match step {
+                Step::Node(cmd) => match cmd.as_ref() {
+                    Command::RenderPass(_) => {
+                        render_passes += 1;
+                    }
+                    Command::ComputePass(_) => {
+                        compute_passes += 1;
+                    }
+                    _ => (),
+                },
                 _ => (),
-            },
-            _ => (),
-        }
-    }
-
-    // Two timestamps for each pass: 1 before and 1 after
-    // plus two timestamps to measure the entire command buffer time.
-    let query_count = NonZeroU32::new(render_passes * 2 + compute_passes * 2 + 2).unwrap();
-    let mut query_pool = queries.get(query_count);
-
-    let mut tmp = TemporaryResources::default();
-
-    let mut barriers = Vec::new();
-
-    unsafe {
-        let index = query_pool.next_index(QueryObject::BeginCommands);
-        encoder.write_timestamp_query(query_pool.pool(), index, TimestampPipelineStage::None);
-    }
-
-    for step in steps {
-        // Batch all barrier steps together, then when the new step is not
-        // a barrier emit all barriers at once.
-        if !barriers.is_empty() && !step.is_barrier() {
-            insert_barriers(resources, &barriers, encoder);
-            barriers.clear();
-        }
-
-        match step {
-            Step::Node(cmd) => match cmd.as_ref() {
-                Command::WriteBuffer(cmd) => {
-                    write_buffer(resources, &mut tmp, cmd);
-                }
-                Command::CopyBufferToBuffer(cmd) => {
-                    copy_buffer_to_buffer(resources, &mut tmp, cmd, encoder);
-                }
-                Command::CopyBufferToTexture(cmd) => {
-                    copy_buffer_to_texture(resources, &mut tmp, cmd, encoder);
-                }
-                Command::CopyTextureToTexture(cmd) => {
-                    copy_texture_to_texture(resources, &mut tmp, cmd, encoder);
-                }
-                Command::TextureTransition(cmd) => {
-                    // The texture is not explicitly used anywhere else, but
-                    // it still must be kept alive for this frame since it
-                    // is used in a barrier.
-                    tmp.textures.insert(cmd.texture.id);
-                }
-                Command::RenderPass(cmd) => {
-                    run_render_pass(resources, &mut tmp, cmd, encoder, &mut query_pool);
-                }
-                Command::ComputePass(cmd) => {
-                    run_compute_pass(resources, &mut tmp, cmd, encoder, &mut query_pool);
-                }
-            },
-            Step::Barrier(barrier) => {
-                barriers.push(barrier);
             }
         }
-    }
 
-    // Flush any remaining barriers.
-    if !barriers.is_empty() {
-        insert_barriers(resources, &barriers, encoder);
-    }
+        // Two timestamps for each pass: 1 before and 1 after
+        // plus two timestamps to measure the entire command buffer time.
+        let query_count = NonZeroU32::new(render_passes * 2 + compute_passes * 2 + 2).unwrap();
+        let mut query_pool = queries.get(query_count);
 
-    unsafe {
-        let index = query_pool.next_index(QueryObject::EndCommands);
-        encoder.write_timestamp_query(query_pool.pool(), index, TimestampPipelineStage::All);
-    }
+        let mut tmp = TemporaryResources::default();
 
-    tmp.query_pool = Some(query_pool);
+        let mut barriers = Vec::new();
 
-    tmp
-}
-
-fn write_buffer(resources: &Resources, tmp: &mut TemporaryResources, cmd: &WriteBuffer) {
-    let buffer = resources.buffers.get(cmd.buffer).unwrap();
-
-    let mut buffer = unsafe { buffer.buffer.borrow_mut() };
-    buffer.map()[cmd.offset as usize..cmd.offset as usize + cmd.data.len()]
-        .copy_from_slice(&cmd.data);
-
-    // If the memory of the buffer is not HOST_COHERENT it needs to
-    // be flushed, otherwise it may never become visible to the device.
-    // TODO: We should batch and do a single flush for all writes.
-    if !buffer.flags().contains(MemoryTypeFlags::HOST_COHERENT) {
         unsafe {
-            buffer.flush();
+            let index = query_pool.next_index(QueryObject::BeginCommands);
+            encoder.write_timestamp_query(query_pool.pool(), index, TimestampPipelineStage::None);
         }
+
+        for step in steps {
+            // Batch all barrier steps together, then when the new step is not
+            // a barrier emit all barriers at once.
+            if !barriers.is_empty() && !step.is_barrier() {
+                insert_barriers(self, &barriers, encoder);
+                barriers.clear();
+            }
+
+            match step {
+                Step::Node(cmd) => match cmd.as_ref() {
+                    Command::CreateBuffer(cmd) => {
+                        let buffer = self.allocator.create_buffer(&cmd.descriptor);
+                        self.buffers.insert(cmd.id, buffer);
+                    }
+                    Command::CreateTexture(cmd) => {
+                        let texture = match cmd.resource.lock().take() {
+                            Some(texture) => TextureData::Physical(texture),
+                            None => {
+                                let texture = self
+                                    .allocator
+                                    .create_texture(&cmd.descriptor, UsageFlags::empty());
+                                TextureData::Virtual(texture)
+                            }
+                        };
+
+                        self.textures.insert(cmd.id, texture);
+                    }
+                    Command::CreateDescriptorSet(id) => {
+                        let set = build_descriptor_set(self, resources, *id);
+
+                        self.descriptor_sets.insert(*id, set);
+                    }
+                    Command::DestoryBuffer(id) => {
+                        debug_assert!(self.buffers.contains_key(id));
+
+                        self.buffers.remove(id);
+                    }
+                    Command::DestroyTexture(id) => {
+                        debug_assert!(self.textures.contains_key(id));
+
+                        self.textures.remove(id);
+                    }
+                    Command::DestroyDescriptorSet(id) => {
+                        debug_assert!(self.descriptor_sets.contains_key(id));
+
+                        self.descriptor_sets.remove(id);
+                    }
+                    Command::WriteBuffer(cmd) => {
+                        let buffer = self.buffers.get_mut(&cmd.buffer).unwrap();
+
+                        buffer.map()[cmd.offset as usize..cmd.offset as usize + cmd.data.len()]
+                            .copy_from_slice(&cmd.data);
+
+                        // If the memory of the buffer is not HOST_COHERENT it needs to
+                        // be flushed, otherwise it may never become visible to the device.
+                        // TODO: We should batch and do a single flush for all writes.
+                        if !buffer.flags().contains(MemoryTypeFlags::HOST_COHERENT) {
+                            unsafe {
+                                buffer.flush();
+                            }
+                        }
+
+                        tmp.buffers.insert(cmd.buffer);
+                    }
+                    Command::CopyBufferToBuffer(cmd) => {
+                        let src = self.buffers.get(&cmd.src).unwrap();
+                        let dst = self.buffers.get(&cmd.dst).unwrap();
+
+                        // SAFETY:
+                        // We have inserted the proper barriers such that the source is
+                        // `TRANSFER_READ` and the destination is `TRANSFER_WRITE`.
+                        unsafe {
+                            encoder.copy_buffer_to_buffer(
+                                src.buffer(),
+                                cmd.src_offset,
+                                dst.buffer(),
+                                cmd.dst_offset,
+                                cmd.count.get(),
+                            );
+                        }
+
+                        // Both buffers must be kept alive until the copy
+                        // operation is complete.
+                        tmp.buffers.insert(cmd.src);
+                        tmp.buffers.insert(cmd.dst);
+                    }
+                    Command::CopyBufferToTexture(cmd) => {
+                        let src = self.buffers.get(&cmd.src).unwrap();
+                        let dst = self.textures.get(&cmd.dst).unwrap();
+
+                        // SAFETY:
+                        // We have inserted the proper barriers such that the source buffer
+                        // is `TRANSFER_READ` and the texture mip is `TRANSFER_WRITE`.
+                        unsafe {
+                            encoder.copy_buffer_to_texture(
+                                CopyBuffer {
+                                    buffer: src.buffer(),
+                                    offset: cmd.src_offset,
+                                    layout: cmd.layout,
+                                },
+                                dst.texture(),
+                                cmd.dst_mip_level,
+                            );
+                        }
+
+                        // Both buffer and texture must be kept alive until the
+                        // copy operation is complete.
+                        tmp.buffers.insert(cmd.src);
+                        tmp.textures.insert(cmd.dst);
+                    }
+                    Command::CopyTextureToTexture(cmd) => {
+                        let src = self.textures.get(&cmd.src).unwrap();
+                        let dst = self.textures.get(&cmd.dst).unwrap();
+
+                        // Safety:
+                        // We have inserted the propert barriers such that the source texture
+                        // is only `TRANSFER_READ` and the destination texture is only
+                        // `TRANSFER_WRITE`.
+                        unsafe {
+                            encoder.copy_texture_to_texture(
+                                src.texture(),
+                                cmd.src_mip_level,
+                                dst.texture(),
+                                cmd.dst_mip_level,
+                            );
+                        }
+
+                        // Both textures need to be kept alive until the copy operation is complete.
+                        tmp.textures.insert(cmd.src);
+                        tmp.textures.insert(cmd.dst);
+                    }
+                    Command::TextureTransition(cmd) => {
+                        // The texture is not explicitly used anywhere else, but
+                        // it still must be kept alive for this frame since it
+                        // is used in a barrier.
+                        tmp.textures.insert(cmd.texture.id);
+                    }
+                    Command::RenderPass(cmd) => {
+                        run_render_pass(self, resources, &mut tmp, cmd, encoder, &mut query_pool);
+                    }
+                    Command::ComputePass(cmd) => {
+                        run_compute_pass(self, resources, &mut tmp, cmd, encoder, &mut query_pool);
+                    }
+                },
+                Step::Barrier(barrier) => {
+                    barriers.push(barrier);
+                }
+            }
+        }
+
+        // Flush any remaining barriers.
+        if !barriers.is_empty() {
+            insert_barriers(self, &barriers, encoder);
+        }
+
+        unsafe {
+            let index = query_pool.next_index(QueryObject::EndCommands);
+            encoder.write_timestamp_query(query_pool.pool(), index, TimestampPipelineStage::All);
+        }
+
+        tmp.query_pool = Some(query_pool);
+
+        tmp
     }
-
-    tmp.buffers.insert(cmd.buffer);
-}
-
-fn copy_buffer_to_buffer(
-    resources: &Resources,
-    tmp: &mut TemporaryResources,
-    cmd: &CopyBufferToBuffer,
-    encoder: &mut CommandEncoder<'_>,
-) {
-    let src = resources.buffers.get(cmd.src).unwrap();
-    let dst = resources.buffers.get(cmd.dst).unwrap();
-
-    // SAFETY:
-    // We have inserted the proper barriers such that the source is
-    // `TRANSFER_READ` and the destination is `TRANSFER_WRITE`.
-    unsafe {
-        encoder.copy_buffer_to_buffer(
-            src.buffer.borrow().buffer(),
-            cmd.src_offset,
-            dst.buffer.borrow().buffer(),
-            cmd.dst_offset,
-            cmd.count.get(),
-        );
-    }
-
-    // Both buffers must be kept alive until the copy
-    // operation is complete.
-    tmp.buffers.insert(cmd.src);
-    tmp.buffers.insert(cmd.dst);
-}
-
-fn copy_buffer_to_texture(
-    resources: &Resources,
-    tmp: &mut TemporaryResources,
-    cmd: &CopyBufferToTexture,
-    encoder: &mut CommandEncoder<'_>,
-) {
-    let buffer = resources.buffers.get(cmd.src).unwrap();
-    let texture = resources.textures.get(cmd.dst).unwrap();
-
-    // SAFETY:
-    // We have inserted the proper barriers such that the source buffer
-    // is `TRANSFER_READ` and the texture mip is `TRANSFER_WRITE`.
-    unsafe {
-        encoder.copy_buffer_to_texture(
-            CopyBuffer {
-                buffer: buffer.buffer.borrow().buffer(),
-                offset: cmd.src_offset,
-                layout: cmd.layout,
-            },
-            texture.texture(),
-            cmd.dst_mip_level,
-        );
-    }
-
-    // Both buffer and texture must be kept alive until the
-    // copy operation is complete.
-    tmp.buffers.insert(cmd.src);
-    tmp.textures.insert(cmd.dst);
-}
-
-fn copy_texture_to_texture(
-    resources: &Resources,
-    tmp: &mut TemporaryResources,
-    cmd: &CopyTextureToTexture,
-    encoder: &mut CommandEncoder<'_>,
-) {
-    let src = resources.textures.get(cmd.src).unwrap();
-    let dst = resources.textures.get(cmd.dst).unwrap();
-
-    // Safety:
-    // We have inserted the propert barriers such that the source texture
-    // is only `TRANSFER_READ` and the destination texture is only
-    // `TRANSFER_WRITE`.
-    unsafe {
-        encoder.copy_texture_to_texture(
-            src.texture(),
-            cmd.src_mip_level,
-            dst.texture(),
-            cmd.dst_mip_level,
-        );
-    }
-
-    // Both textures need to be kept alive until the copy operation is complete.
-    tmp.textures.insert(cmd.src);
-    tmp.textures.insert(cmd.dst);
 }
 
 fn run_render_pass(
+    executor: &mut Executor,
     resources: &Resources,
     tmp: &mut TemporaryResources,
     cmd: &RenderPassCmd,
     encoder: &mut CommandEncoder<'_>,
     query_pool: &mut ManagedQueryPool,
 ) {
-    // Ensure all physical descriptor sets are created before
-    // the render pass begins.
-    for cmd in &cmd.cmds {
-        match cmd {
-            DrawCmd::SetDescriptorSet(_, id) => {
-                let set = resources.descriptor_sets.get(*id).unwrap();
-                if unsafe { set.descriptor_set.borrow().is_none() } {
-                    build_descriptor_set(resources, *id);
-                }
-            }
-            _ => (),
-        }
-    }
-
     let attachment_views = ScratchBuffer::new(
         cmd.color_attachments.len() + usize::from(cmd.depth_stencil_attachment.is_some()),
     );
 
     let mut color_attachments = Vec::new();
     for attachment in &cmd.color_attachments {
-        let texture = resources.textures.get(attachment.target.texture).unwrap();
+        let texture = executor.textures.get(&attachment.target.texture).unwrap();
+
         // Attachment must be kept alive until the render pass completes.
         tmp.textures.insert(attachment.target.texture);
 
@@ -278,7 +289,7 @@ fn run_render_pass(
     }
 
     let depth_attachment = cmd.depth_stencil_attachment.as_ref().map(|attachment| {
-        let texture = resources.textures.get(attachment.texture).unwrap();
+        let texture = executor.textures.get(&attachment.texture).unwrap();
 
         // Attachment must be kept alive until the render pass completes.
         tmp.textures.insert(attachment.texture);
@@ -335,20 +346,18 @@ fn run_render_pass(
                 tmp.pipelines.insert(*id);
             }
             DrawCmd::SetDescriptorSet(index, id) => {
-                let set = resources.descriptor_sets.get(*id).unwrap();
-                let set = unsafe { set.descriptor_set.borrow() };
-                let set = set.as_ref().unwrap().raw();
-                render_pass.bind_descriptor_set(*index, set);
+                let set = executor.descriptor_sets.get(id).unwrap();
+
+                render_pass.bind_descriptor_set(*index, set.set.raw());
 
                 // Descriptor set must be kept alive until the render pass
                 // completes.
                 tmp.descriptor_sets.insert(*id);
             }
             DrawCmd::SetIndexBuffer(id, format) => {
-                let buffer = resources.buffers.get(*id).unwrap();
-                unsafe {
-                    render_pass.bind_index_buffer(buffer.buffer.borrow().buffer_view(), *format);
-                }
+                let buffer = executor.buffers.get(id).unwrap();
+
+                render_pass.bind_index_buffer(buffer.buffer_view(), *format);
 
                 // Index buffer must be kept alive until the render pass
                 // completes.
@@ -368,10 +377,10 @@ fn run_render_pass(
                 );
             }
             DrawCmd::Draw(DrawCall::DrawIndirect(call)) => {
-                let buffer = resources.buffers.get(call.buffer).unwrap();
+                let buffer = executor.buffers.get(&call.buffer).unwrap();
 
                 render_pass.draw_indirect(
-                    unsafe { buffer.buffer.borrow().buffer() },
+                    buffer.buffer(),
                     call.offset,
                     call.count,
                     size_of::<DrawIndirectCommand>() as u32,
@@ -380,10 +389,10 @@ fn run_render_pass(
                 tmp.buffers.insert(call.buffer);
             }
             DrawCmd::Draw(DrawCall::DrawIndexedIndirect(call)) => {
-                let buffer = resources.buffers.get(call.buffer).unwrap();
+                let buffer = executor.buffers.get(&call.buffer).unwrap();
 
                 render_pass.draw_indexed_indirect(
-                    unsafe { buffer.buffer.borrow().buffer() },
+                    buffer.buffer(),
                     call.offset,
                     call.count,
                     size_of::<DrawIndexedIndirectCommand>() as u32,
@@ -409,26 +418,13 @@ fn run_render_pass(
 }
 
 fn run_compute_pass(
+    executor: &mut Executor,
     resources: &Resources,
     tmp: &mut TemporaryResources,
     cmd: &ComputePassCmd,
     encoder: &mut CommandEncoder<'_>,
     query_pool: &mut ManagedQueryPool,
 ) {
-    // Ensure all physical descriptor sets are created before
-    // the render pass begins.
-    for cmd in &cmd.cmds {
-        match cmd {
-            ComputeCommand::SetDescriptorSet(_, id) => {
-                let set = resources.descriptor_sets.get(*id).unwrap();
-                if unsafe { set.descriptor_set.borrow().is_none() } {
-                    build_descriptor_set(resources, *id);
-                }
-            }
-            _ => (),
-        }
-    }
-
     // Record a timestamp before running the compute pass.
     unsafe {
         let index = query_pool.next_index(QueryObject::BeginPass(cmd.name));
@@ -455,10 +451,9 @@ fn run_compute_pass(
                 tmp.pipelines.insert(*id);
             }
             ComputeCommand::SetDescriptorSet(index, id) => {
-                let set = resources.descriptor_sets.get(*id).unwrap();
-                let set = unsafe { set.descriptor_set.borrow() };
-                let set = set.as_ref().unwrap().raw();
-                compute_pass.bind_descriptor_set(*index, set);
+                let set = executor.descriptor_sets.get(id).unwrap();
+
+                compute_pass.bind_descriptor_set(*index, set.set.raw());
 
                 // Descriptor set must be kept alive until the render pass
                 // completes.
@@ -482,7 +477,11 @@ fn run_compute_pass(
     }
 }
 
-fn build_descriptor_set(resources: &Resources, id: DescriptorSetId) {
+fn build_descriptor_set(
+    executor: &Executor,
+    resources: &Resources,
+    id: DescriptorSetId,
+) -> DescriptorSetInner {
     let _span = trace_span!("build_descriptor_set").entered();
 
     let descriptor_set = resources.descriptor_sets.get(id).unwrap();
@@ -500,25 +499,21 @@ fn build_descriptor_set(resources: &Resources, id: DescriptorSetId) {
     for (binding, resource) in descriptor_set.bindings.iter() {
         let resource = match resource {
             DescriptorSetResource::UniformBuffer(buffer) => {
-                let buffer = resources.buffers.get(*buffer).unwrap();
-                let buffer =
-                    unsafe { &*(buffer.buffer.borrow().buffer() as *const vulkan::Buffer) };
-                let view = buffer.slice(..);
+                let buffer = executor.buffers.get(buffer).unwrap();
+                let view = buffer.buffer_view();
                 let view = buffer_views.insert(view);
 
                 WriteDescriptorResource::UniformBuffer(slice::from_ref(view))
             }
             DescriptorSetResource::StorageBuffer(buffer) => {
-                let buffer = resources.buffers.get(*buffer).unwrap();
-                let buffer =
-                    unsafe { &*(buffer.buffer.borrow().buffer() as *const vulkan::Buffer) };
-                let view = buffer.slice(..);
+                let buffer = executor.buffers.get(buffer).unwrap();
+                let view = buffer.buffer_view();
                 let view = buffer_views.insert(view);
 
                 WriteDescriptorResource::StorageBuffer(slice::from_ref(view))
             }
             DescriptorSetResource::Texture(view) => {
-                let texture = resources.textures.get(view.texture).unwrap();
+                let texture = executor.textures.get(&view.texture).unwrap();
                 let view = texture_views.insert(unsafe {
                     texture
                         .texture()
@@ -535,7 +530,7 @@ fn build_descriptor_set(resources: &Resources, id: DescriptorSetId) {
                 let texture_views = texture_array_views.insert(ScratchBuffer::new(views.len()));
 
                 for view in views {
-                    let texture = resources.textures.get(view.texture).unwrap();
+                    let texture = executor.textures.get(&view.texture).unwrap();
 
                     texture_views.insert(unsafe {
                         texture
@@ -561,56 +556,35 @@ fn build_descriptor_set(resources: &Resources, id: DescriptorSetId) {
         bindings.push(WriteDescriptorBinding { binding, resource });
     }
 
-    let mut set = unsafe { resources.descriptor_allocator.alloc(&layout.inner).unwrap() };
+    let mut set = resources.descriptor_allocator.alloc(&layout.inner).unwrap();
     unsafe {
         set.raw_mut().update(&WriteDescriptorResources {
             bindings: &bindings,
         });
     }
 
-    let mut physical_texture_views = unsafe { descriptor_set.physical_texture_views.borrow_mut() };
-    physical_texture_views.extend(texture_views);
-    for texture_views in texture_array_views {
-        physical_texture_views.extend(texture_views);
+    let mut textures = Vec::new();
+    textures.extend(texture_views);
+    for views in texture_array_views {
+        textures.extend(views);
     }
 
-    unsafe {
-        *descriptor_set.descriptor_set.borrow_mut() = Some(set);
-    }
+    DescriptorSetInner { set, textures }
 }
 
 fn insert_barriers(
-    resources: &Resources,
+    executor: &mut Executor,
     barriers: &[Barrier<ResourceId>],
     encoder: &mut CommandEncoder<'_>,
 ) {
     let mut buffer_barriers = Vec::new();
     let mut texture_barriers = Vec::new();
 
-    let mut buffers = Vec::new();
-    let mut textures = Vec::new();
     for barrier in barriers {
         match barrier.resource {
             ResourceId::Buffer(id) => {
-                let buffer = resources.buffers.get(id).unwrap();
-                unsafe {
-                    let buffer = buffer.buffer.borrow();
-                    buffers.push(&*(&*buffer as *const BufferAlloc));
-                }
-            }
-            ResourceId::Texture(tex) => {
-                let texture = resources.textures.get(tex.id).unwrap();
-                textures.push(unsafe { &*(&*texture.texture() as *const vulkan::Texture) });
-            }
-        }
-    }
-    let mut buffers = buffers.iter();
-    let mut textures = textures.iter();
+                let buffer = executor.buffers.get(&id).unwrap();
 
-    for barrier in barriers {
-        match barrier.resource {
-            ResourceId::Buffer(id) => {
-                let buffer = buffers.next().unwrap();
                 buffer_barriers.push(BufferBarrier {
                     buffer: buffer.buffer(),
                     offset: buffer.buffer_view().offset(),
@@ -620,9 +594,10 @@ fn insert_barriers(
                 });
             }
             ResourceId::Texture(tex) => {
-                let texture = textures.next().unwrap();
+                let texture = executor.textures.get(&tex.id).unwrap();
+
                 texture_barriers.push(TextureBarrier {
-                    texture: texture,
+                    texture: texture.texture(),
                     src_access: barrier.src_access,
                     dst_access: barrier.dst_access,
                     base_mip_level: tex.mip_level,
@@ -742,6 +717,27 @@ where
     {
         for elem in iter {
             self.insert(elem);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DescriptorSetInner {
+    set: AllocatedDescriptorSet,
+    textures: Vec<TextureView<'static>>,
+}
+
+#[derive(Debug)]
+pub enum TextureData {
+    Physical(vulkan::Texture),
+    Virtual(TextureAlloc),
+}
+
+impl TextureData {
+    pub fn texture(&self) -> &vulkan::Texture {
+        match &self {
+            Self::Physical(tex) => tex,
+            Self::Virtual(tex) => tex.texture(),
         }
     }
 }

--- a/game_render/src/backend/descriptors.rs
+++ b/game_render/src/backend/descriptors.rs
@@ -55,11 +55,7 @@ impl DescriptorSetAllocator {
         }
     }
 
-    // FIXME: Why is this unsafe again?
-    pub unsafe fn alloc(
-        &self,
-        layout: &DescriptorSetLayout,
-    ) -> Result<AllocatedDescriptorSet, Error> {
+    pub fn alloc(&self, layout: &DescriptorSetLayout) -> Result<AllocatedDescriptorSet, Error> {
         let _span = trace_span!("DescriptorSetAllocator::alloc").entered();
 
         let mut count = DescriptorSetResourceCount::default();

--- a/game_render/src/backend/mod.rs
+++ b/game_render/src/backend/mod.rs
@@ -5,7 +5,7 @@ pub mod vulkan;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::ops::Range;
 
-use ash::vk::{self, DecompressMemoryRegionNV};
+use ash::vk;
 use bitflags::bitflags;
 use bytemuck::{Pod, Zeroable};
 use game_common::components::Color;
@@ -620,7 +620,7 @@ impl<'a> BufferView<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct TextureDescriptor {
     pub size: UVec2,
     pub mip_levels: u32,


### PR DESCRIPTION
This is a cleaner separation between virtual and physical resources and opens up the possibility for optimizations like memory aliasing and pipelining in the future.