### PR TITLE
Remove `raw-window-handle 0.5` dependency

### DIFF
--- a/game_window/Cargo.toml
+++ b/game_window/Cargo.toml
@@ -14,8 +14,7 @@ game_input = { version = "0.1.0", path = "../game_input" }
 game_tracing = { version = "0.1.0", path = "../game_tracing" }
 
 glam = "0.28.0"
-# wgpu 0.18 still depends on raw-window-handle 0.5
-winit = { version = "0.29.4", features = ["rwh_05"] }
+winit = "0.29.4"
 tracing = "0.1.40"
 raw-window-handle = "0.6.0"
 parking_lot = "0.12.3"


### PR DESCRIPTION
This was still enabled from the time where we used wgpu and is no longer needed.