### PR TITLE
Use `f16` colors instead of `f32` for transparency A-Buffer

### DIFF
--- a/game_core_pipeline/shaders/transparent/shared.slang
+++ b/game_core_pipeline/shaders/transparent/shared.slang
@@ -32,7 +32,7 @@ public struct MeshOffsets {
 }
 
 public struct Element {
-    public Vec4 color;
+    public vector<f16, 4> color;
     public f32 depth;
     public u32 next;
 }

--- a/game_core_pipeline/shaders/transparent/transparent_blend.slang
+++ b/game_core_pipeline/shaders/transparent/transparent_blend.slang
@@ -57,31 +57,11 @@ void main(
     var color = output[coords];
 
     for (int i = 0; i < layer_count; i++) {
-
-        // if (color.a > 0.5) {
-            let premult = Vec4(layers[i].color.rgb * layers[i].color.a, layers[i].color.a);
-            color.rgb = (1.0 - premult.a) * color.rgb + premult.rgb;
-            color.a = color.a + premult.a - color.a * premult.a;
-
-            // color.rgb = color.rgb + premult.rgb;
-            // color.rgb = color.rgb - premult.rgb;
-            // color.rgb = color.rgb;
-
-            let nan = 0.0 / 0.0;
-
-    // if (color.r == nan || color.g == nan || color.b == nan) {
-    //     color = Vec4(1.0, 1.0, 1.0, 1.0);
-    // }
-
-            // color = premult;
-        // }
+        let top = Vec4(layers[i].color);
+        let premult = Vec4(top.rgb * top.a, top.a);
+        color.rgb = (1.0 - premult.a) * color.rgb + premult.rgb;
+        color.a = color.a + premult.a - color.a * premult.a;
     }
-
-    // let nan = 0.0 / 0.0;
-
-    // if (color.r == nan || color.g == nan || color.b == nan) {
-    //     color = Vec4(1.0, 1.0, 1.0, 1.0);
-    // }
 
     output[coords] = color;
 }

--- a/game_core_pipeline/shaders/transparent/transparent_frag.slang
+++ b/game_core_pipeline/shaders/transparent/transparent_frag.slang
@@ -64,7 +64,7 @@ func main(input: Input) {
     var prev = 0;
     InterlockedExchange(heads[vector<u32, 2>(input.clip_position.xy)], index, prev);
 
-    elements[index].color = color;
+    elements[index].color = vector<f16, 4>(color);
     elements[index].depth = input.clip_position.z;
     elements[index].next = prev;
 }

--- a/game_core_pipeline/src/passes/transparent_vertex.rs
+++ b/game_core_pipeline/src/passes/transparent_vertex.rs
@@ -299,8 +299,8 @@ impl TransparentVertexPass {
         let size = color_target.size();
 
         // Size for at least four layers if every pixel is covered.
-        // The size of one element is 24 bytes.
-        let abuffer_size = size.x as u64 * size.y as u64 * 4 * 24;
+        // The size of one element is 16 bytes.
+        let abuffer_size = size.x as u64 * size.y as u64 * 4 * 16;
 
         if mesh_state.num_transparent_instances == 0 || size.x == 0 || size.y == 0 {
             return;

--- a/game_render/src/backend/vulkan.rs
+++ b/game_render/src/backend/vulkan.rs
@@ -634,6 +634,7 @@ impl Adapter {
 
         DeviceFeatures {
             mutli_draw_indirect: cast(features.multi_draw_indirect),
+            storage_buffer_16bit_access: cast(features11.storage_buffer16_bit_access),
             shader_draw_parameters: cast(features11.shader_draw_parameters),
             shader_input_attachment_array_dynamic_indexing: cast(
                 features12.shader_input_attachment_array_dynamic_indexing,
@@ -891,6 +892,7 @@ impl Adapter {
         extensions.extend(supported_extensions.names().iter().map(|v| v.as_ptr()));
 
         let required_features = DeviceFeatures {
+            storage_buffer_16bit_access: true,
             mutli_draw_indirect: true,
             shader_draw_parameters: true,
             shader_input_attachment_array_dynamic_indexing: true,
@@ -941,7 +943,8 @@ impl Adapter {
             // Enables `SPV_KHR_shader_draw_parameters`, which in turns provides
             // `BaseInstance`, `BaseVertex` and `DrawIndex` needed for indirect
             // draws.
-            .shader_draw_parameters(true);
+            .shader_draw_parameters(true)
+            .storage_buffer16_bit_access(true);
 
         let mut features12 = vk::PhysicalDeviceVulkan12Features::default()
             // Runtime Descriptor indexing
@@ -5242,6 +5245,8 @@ impl<'a> FromIterator<&'a CStr> for DeviceExtensions {
 pub struct DeviceFeatures {
     /// Vulkan 1.0
     mutli_draw_indirect: bool,
+    /// Vulkan 1.1 or `VK_KHR_16bit_storage`
+    storage_buffer_16bit_access: bool,
     /// Vulkan 1.1 or `VK_KHR_shader_draw_parameters`
     shader_draw_parameters: bool,
     /// Vulkan 1.2 or `VK_EXT_descriptor_indexing`
@@ -5315,6 +5320,7 @@ impl DeviceFeatures {
 
         let Self {
             mutli_draw_indirect,
+            storage_buffer_16bit_access,
             shader_draw_parameters,
             shader_input_attachment_array_dynamic_indexing,
             shader_uniform_texel_buffer_array_dynamic_indexing,
@@ -5359,6 +5365,7 @@ impl DeviceFeatures {
 
         set_missing_feature_flags! {
             mutli_draw_indirect,
+            storage_buffer_16bit_access,
             shader_draw_parameters,
             shader_input_attachment_array_dynamic_indexing,
             shader_uniform_texel_buffer_array_dynamic_indexing,
@@ -5403,6 +5410,7 @@ impl DeviceFeatures {
     fn is_empty(&self) -> bool {
         let Self {
             mutli_draw_indirect,
+            storage_buffer_16bit_access,
             shader_draw_parameters,
             shader_input_attachment_array_dynamic_indexing,
             shader_uniform_texel_buffer_array_dynamic_indexing,
@@ -5438,6 +5446,7 @@ impl DeviceFeatures {
         } = *self;
 
         let is_not_empty = mutli_draw_indirect
+            || storage_buffer_16bit_access
             || shader_draw_parameters
             || shader_input_attachment_array_dynamic_indexing
             || shader_uniform_texel_buffer_array_dynamic_indexing
@@ -5478,6 +5487,7 @@ impl DeviceFeatures {
 impl Display for DeviceFeatures {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let Self {
+            storage_buffer_16bit_access,
             mutli_draw_indirect,
             shader_draw_parameters,
             shader_input_attachment_array_dynamic_indexing,
@@ -5528,6 +5538,7 @@ impl Display for DeviceFeatures {
         }
 
         let strings = create_strings! {
+            storage_buffer_16bit_access,
             mutli_draw_indirect,
             shader_draw_parameters,
             shader_input_attachment_array_dynamic_indexing,


### PR DESCRIPTION
This reduces memory usage for the A-Buffer by 33% at minimal visual degradation.