### PR TITLE
Replace "priority commands" with regular commands

### DIFF
--- a/game_render/src/api/mod.rs
+++ b/game_render/src/api/mod.rs
@@ -118,17 +118,12 @@ impl CommandExecutor {
 
         let cmd_stream = self.cmds.get_mut();
 
-        let cmds = cmd_stream.cmd_refs();
+        let cmds = cmd_stream.commands();
 
-        let mut steps = self
+        let steps = self
             .scheduler
             .schedule(&*self.resources, &*allocator, &cmds);
         allocator.reset();
-
-        let prio_cmds = cmd_stream.priority_cmds();
-        for (index, cmd) in prio_cmds.iter().enumerate() {
-            steps.insert(index, scheduler::Step::Node(cmd));
-        }
 
         let tmp = self
             .executor


### PR DESCRIPTION
We can directly implement these by pretending to access to underlying resource that is created. Destruction commands have no dependencies and were already valid.

This removes the need for having a special handling of some "priority" commands and an unnecesary copy that merges both regular commands and "priority commands" after scheduling.